### PR TITLE
Fix all the things for PHP 7.3

### DIFF
--- a/src/break.c
+++ b/src/break.c
@@ -432,7 +432,7 @@ static int php_inspector_break_handler(zend_execute_data *execute_data) {
 	BRK(state) = INSPECTOR_BREAK_RUNTIME;
 
 	if (EG(exception)) {
-#if PHP_VERSION_ID >= 70200 && PHP_VERSION_ID < 70300
+#if PHP_VERSION_ID >= 70200
 		const zend_op *throw = EG(opline_before_exception);
 
 		if (throw->result_type & (IS_VAR|IS_TMP_VAR)) {

--- a/src/operand.c
+++ b/src/operand.c
@@ -291,7 +291,11 @@ static PHP_METHOD(InspectorOperand, getNumber) {
 
 	switch (zend_op_type(operand->type)) {
 		case IS_CONST:
+#if PHP_VERSION_ID >= 70300
+			RETURN_LONG(function->literals - RT_CONSTANT(instruction->opline, *operand->op));
+#else
 			RETURN_LONG(function->literals - RT_CONSTANT(function, *operand->op));
+#endif
 		case IS_VAR:
 		case IS_TMP_VAR:
 			RETURN_LONG(EX_VAR_TO_NUM(operand->op->num - function->last_var));


### PR DESCRIPTION
Removing the isJumpTarget() tests as anyway already covered by the getNumber tests and a bit confusing due to the differences in versions.